### PR TITLE
Add ability to pass smartblock cmd to REPEAT to iterate over

### DIFF
--- a/docs/050-command-reference.md
+++ b/docs/050-command-reference.md
@@ -128,7 +128,7 @@ Serendipity commands are commands that help resolve to a random block from your 
 **Parameters**:
 
 1. Page to pull a child from. Could be either:
-   - Option 1: **Page name **or **tag name** (brackets `[[]]` or hashtag `#` are optional)
+   - Option 1: **Page name** or **tag name** (brackets `[[]]` or hashtag `#` are optional)
    - Option 2: Parent block UID
 2. Levels within the page to include. Specifying 0 includes all blocks
 3. Format to output the block in. See our [Formatting](050-command-reference.md#formatting) section for more info.
@@ -154,7 +154,7 @@ Serendipity commands are commands that help resolve to a random block from your 
 
 **Parameters**: One parameter that could be either:
 
-- Option 1: **Page name **or **tag name** (brackets `[[]]` or hashtag `#` are optional)
+- Option 1: **Page name** or **tag name** (brackets `[[]]` or hashtag `#` are optional)
 - Option 2: Parent block UID
 
 **Example**:
@@ -532,8 +532,8 @@ Special note: if you want a comma to be a part of the output, put a \ in front o
 
 **Example**:
 
-- `<%RESOLVEBLOCKREF:**abcdefghi**%>`
-- `<%RESOLVEBLOCKREF:**`((abcdefghi))`**%>`
+- `<%RESOLVEBLOCKREF:abcdefghi%>`
+- `<%RESOLVEBLOCKREF:((abcdefghi))%>`
 
 ## SEARCH
 
@@ -706,7 +706,7 @@ If no value is specified, it's the same as checking if the block is empty
 
 **Example**:
 
-- ``<%IFMATCH:foo,true%>`
+- `<%IFMATCH:foo,true%>`
   - - checks if variable `foo` has value `true`. If no variable `foo` exists, it then checks to see if `foo` is equal in value to `true`, which would keep the block
 
 ## IFDATEOFYEAR
@@ -983,14 +983,26 @@ If it isn't, the block is not inserted
 
 **Purpose**: Repeats the second argument a specified amount of times.
 
+If `Count of repeats` is a dash (`-`), then `Count of repeats` will be set to the number of results from `Items to iterate over`
+
+This also passes SmartBlock variables:
+
+- `ITERATION`: returns the current loop (eg: `1`, `2`, etc).
+- `ITERATIONVALUE`: retuns the item being iterated over from `Items to iterate over`
+
 **Parameters**:
 
 1. Count of repeats
 2. Content to repeat
+3. (Optional) Items to iterate over. Accepts a SmartBlock command.
 
 **Example**:
 
 - `<%REPEAT:5,hello%>`
+- `<%REPEAT:-,<%SMARTBLOCK:runMe%>,<%CHILDREN:((someUid))%>%>`
+- runMe #SmartBlock
+  - `<%GET:ITERATION%>`
+  - `<%GET:ITERATIONVALUE%>`
 
 # **Cursor Commands**
 

--- a/docs/050-command-reference.md
+++ b/docs/050-command-reference.md
@@ -983,23 +983,22 @@ If it isn't, the block is not inserted
 
 **Purpose**: Repeats the second argument a specified amount of times.
 
-If `Count of repeats` is a dash (`-`), then `Count of repeats` will be set to the number of results from `Items to iterate over`
+If the first argument is another command (eg `<%CHILDREN%>`), then `Count of repeats` will be set to the number of results from that command.
 
 This also passes SmartBlock variables:
 
 - `ITERATION`: returns the current loop (eg: `1`, `2`, etc).
-- `ITERATIONVALUE`: retuns the item being iterated over from `Items to iterate over`
+- `ITERATIONVALUE`: returns the item being iterated over from the first argument.
 
 **Parameters**:
 
-1. Count of repeats
+1. Count of repeats (or a SmartBlock command that returns items to iterate over)
 2. Content to repeat
-3. (Optional) Items to iterate over. Accepts a SmartBlock command.
 
 **Example**:
 
 - `<%REPEAT:5,hello%>`
-- `<%REPEAT:-,<%SMARTBLOCK:runMe%>,<%CHILDREN:((someUid))%>%>`
+- `<%REPEAT:<%CHILDREN:((someUid))%>,<%SMARTBLOCK:runMe%>%>`
 - runMe #SmartBlock
   - `<%GET:ITERATION%>`
   - `<%GET:ITERATIONVALUE%>`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "smartblocks",
-  "version": "1.6.11",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "smartblocks",
-      "version": "1.6.11",
+      "version": "1.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smartblocks",
-  "version": "1.6.11",
+  "version": "1.7.0",
   "description": "Create custom and programmable templates from within Roam!",
   "main": "./build/main.js",
   "scripts": {

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -1731,24 +1731,17 @@ export const COMMANDS: {
   {
     text: "REPEAT",
     delayArgs: true,
-    help: "Repeats the current block a number of specified times\n\n1. Number of times for repeat",
-    handler: (repeatArg = "1", content = "") =>
-      proccessBlockText(repeatArg)
-        .then(([{ text }]) =>
-          Array(Number(text) || 1)
-            .fill(content)
-            .map((s) => () => proccessBlockText(s))
-            .reduce(
-              (prev, cur) =>
-                prev.then((p) =>
-                  cur().then((c) => {
-                    return [...p, c];
-                  })
-                ),
-              Promise.resolve([] as InputTextNode[][])
-            )
-        )
-        .then((s) => s.flatMap((c) => c)),
+    help: "Repeats the current block a specified number of times\n\n1. Number of times for repeat",
+    handler: async (repeatArg = "1", content = "") => {
+      const [{ text: repeatArgText }] = await proccessBlockText(repeatArg);
+      const repeatCount = Number(repeatArgText) || 1;
+      const results = [];
+      for (let i = 0; i < repeatCount; i++) {
+        const result = await proccessBlockText(content);
+        results.push(result);
+      }
+      return results.flatMap((c) => c);
+    },
   },
   {
     text: "DATEBASIS",

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -1730,13 +1730,15 @@ export const COMMANDS: {
   },
   {
     text: "REPEAT",
-    delayArgs: true,
+    delayArgs: [true, true, false],
     help: "Repeats the current block a specified number of times\n\n1. Number of times for repeat",
-    handler: async (repeatArg = "1", content = "") => {
+    handler: async (repeatArg = "1", content = "", ...values) => {
       const [{ text: repeatArgText }] = await proccessBlockText(repeatArg);
       const repeatCount = Number(repeatArgText) || 1;
       const results = [];
       for (let i = 0; i < repeatCount; i++) {
+        smartBlocksContext.variables["ITERATION"] = (i + 1).toString();
+        smartBlocksContext.variables["ITERATIONVALUE"] = values[i] || "";
         const result = await proccessBlockText(content);
         results.push(result);
       }
@@ -2294,17 +2296,17 @@ const processBlockTextToPromises = (s: string) => {
     };
 
     return processArgs(args, delayArgs)
-            .then((s) => {
-              if (!s.length) return { args: [], nodeProps: {} };
-              return {
-                args: s.flatMap((c) => flattenText(c)),
-                nodeProps: s.reduce((prev, cur) => {
-                  const nodeProps = { ...cur[0] } || ({} as InputTextNode);
-                  const { text, uid, children, ...rest } = nodeProps;
-                  return { ...prev, ...rest };
-                }, {}),
-              };
-            })
+      .then((s) => {
+        if (!s.length) return { args: [], nodeProps: {} };
+        return {
+          args: s.flatMap((c) => flattenText(c)),
+          nodeProps: s.reduce((prev, cur) => {
+            const nodeProps = { ...cur[0] } || ({} as InputTextNode);
+            const { text, uid, children, ...rest } = nodeProps;
+            return { ...prev, ...rest };
+          }, {}),
+        };
+      })
       .then(({ args, nodeProps }) =>
         !!handler
           ? Promise.resolve(handler(...args)).then((output) => ({

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -1743,7 +1743,7 @@ export const COMMANDS: {
         const result = await proccessBlockText(content);
         results.push(result);
       }
-      return results.flatMap((c) => c);
+      return results.flat();
     },
   },
   {
@@ -2285,15 +2285,15 @@ const processBlockTextToPromises = (s: string) => {
           ? Array(args.length).fill(delayArgs)
           : delayArgs;
 
-      const argPromises = args.map((arg, i) => {
+      return args.reduce(async (prev, arg, i) => {
+        const p = await prev;
         if (delayArgsArray[i]) {
-          return Promise.resolve([{ text: arg }]);
+          return [...p, [{ text: arg }]];
         } else {
-          return proccessBlockText(arg);
+          const blockTextResult = await proccessBlockText(arg);
+          return [...p, blockTextResult];
         }
-      });
-
-      return Promise.all(argPromises);
+      }, Promise.resolve([] as InputTextNode[][]));
     };
 
     return processArgs(args, delayArgs)

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -490,7 +490,7 @@ const stripUid = (n: InputTextNode[] = []): InputTextNode[] =>
 export const COMMANDS: {
   text: string;
   help: string;
-  delayArgs?: boolean | boolean[];
+  delayArgs?: true;
   handler: CommandHandler;
   illegal?: true;
 }[] = [

--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -1734,7 +1734,8 @@ export const COMMANDS: {
     help: "Repeats the current block a specified number of times\n\n1. Number of times for repeat",
     handler: async (repeatArg = "1", content = "", ...values) => {
       const [{ text: repeatArgText }] = await proccessBlockText(repeatArg);
-      const repeatCount = Number(repeatArgText) || 1;
+      const repeatCount =
+        repeatArg === "-" ? values.length : Number(repeatArgText) || 1;
       const results = [];
       for (let i = 0; i < repeatCount; i++) {
         smartBlocksContext.variables["ITERATION"] = (i + 1).toString();


### PR DESCRIPTION
Exposes these variables during the loop
- `smartBlocksContext.variables["ITERATION"] = (i + 1).toString();`
- `smartBlocksContext.variables["ITERATIONVALUE"] = values[i] || "";`

~~iteration value comes from last argument in `<%REPEAT%>`~~
`<%REPEAT:<%CHILDREN:((someUid))%>,<%SMARTBLOCK:runMe%>`