### PR TITLE
Fix small issue, more params for `RANDOMCHILDOF` and new smartblock command `FIRSTCHILDOFMENTION`

### DIFF
--- a/src/utils/core.ts
+++ b/src/utils/core.ts
@@ -153,7 +153,7 @@ const getDateBasisDate = () => {
   }
 };
 
-const getTreeAtLevel = (
+const getTreeUptoLevel = (
   tree: RoamBasicNode[],
   level: number
 ): RoamBasicNode[] => {
@@ -162,7 +162,7 @@ const getTreeAtLevel = (
   }
   return tree.map((t) => ({
     ...t,
-    children: getTreeAtLevel(tree, level - 1),
+    children: getTreeUptoLevel(t.children, level - 1),
   }));
 };
 
@@ -183,7 +183,7 @@ const getLevelsBelowParentUid = (
   const parentUid = getUidFromText(titleOrUid);
   const levels = Number(levelsIncluded) || 0;
   const tree = getBasicTreeByParentUid(parentUid);
-  return levels <= 0 || !levels ? tree : getTreeAtLevel(tree, levels);
+  return levels <= 0 || !levels ? tree : getTreeUptoLevel(tree, levels);
 };
 
 addNlpDateParser({


### PR DESCRIPTION
@mdroidian @dvargas92495 

Video explaining this PR: https://www.loom.com/share/8289de7d9d4c4439b6295f26a7c31c21

- fix recursion bug for smartblocks which accept `levelsIncluded` param
    - Output:: https://github.com/RoamJS/smartblocks/commit/ae1b2e75e76e7051081b74a80411efa84bbf7892
-  add params `levelsIncluded`, `format` and optional filter values i.e. `search` in SB `RANDOMCHILDOF`
    - that SB should maybe be named `RANDOMCHILDOFMENTION` but IDK if we can change that
    - Output:: https://github.com/RoamJS/smartblocks/commit/fadb3d8d14a3dfe0eddbf546286ff437765f6eda
- add `FIRSTCHILDOFMENTION` smart block
    - Output:: https://github.com/RoamJS/smartblocks/commit/d0e6e555d6852132c5a92f9da36ade9551984771

Video: New SmartBlocks Features demo using "One article a day" workflow: https://www.loom.com/share/72b75508e86c45da93d645902736d49a
(which uses the changes from this PR)