### PR TITLE
Add order to SMARTBLOCK

### DIFF
--- a/docs/050-command-reference.md
+++ b/docs/050-command-reference.md
@@ -1098,11 +1098,13 @@ To set the default text of `embed`, set a variable named the same as the name of
 
 1. The workflow name
 2. An optional page name to execute the workflow on another page. The command will return a block reference to the other page if this parameter is set.
+3. When the second parameter is set, you may optionally pass a number to specify the order of the new block on that page.
 
 **Example:**
 
 - `<%SMARTBLOCK:Daily%>`
 - `<%SMARTBLOCK:Daily,<%DATE:Tomorrow%>%>`
+- `<%SMARTBLOCK:Daily,Some Page,2%>`
 
 ## REPEAT
 


### PR DESCRIPTION
## Summary
- allow passing an order to `sbBomb` when running SMARTBLOCKs
- update SMARTBLOCK command docs with optional order parameter
- update SMARTBLOCK handler to accept order as third parameter

## Testing
- `npm test` *(fails: samepage not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869c48c140c8326a8f5dd83cc22ccb3