### PR TITLE
feat: allow unlabeled SmartBlock buttons

### DIFF
--- a/docs/060-alternative-methods.md
+++ b/docs/060-alternative-methods.md
@@ -37,6 +37,8 @@ By default, the workflow runs any time after midnight each day. If you would lik
 You can insert a button into a block so the button will run a SmartBlock workflow when the user clicks on it. To do this, insert a button using the following syntax:
 
 - `{{caption:SmartBlock:workflow name}}`
+- If you would like the button to display no caption, simply omit the first parameter:
+  - `{{:SmartBlock:workflow name}}`
 - First, you notice the syntax starts with `{{` and also ends with `}}`
 - Three parameters separated by a `:`
   1. **Caption** - the name that will appear on the button. (Do not use caption names that conflict with other Roam features, like: table, kanban, test)

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import { runDaily } from "./utils/scheduleNextDailyRun";
 import getFullTreeByParentUid from "roamjs-components/queries/getFullTreeByParentUid";
 import { zCommandOutput } from "./utils/zodTypes";
 import { IconNames } from "@blueprintjs/icons";
+import parseSmartBlockButton from "./utils/parseSmartBlockButton";
 
 const getLegacy42Setting = (name: string) => {
   const settings = Object.fromEntries(
@@ -542,30 +543,13 @@ export default runExtension(async ({ extensionAPI }) => {
     text: string;
     el: HTMLElement;
     parentUid: string;
-    hideIcon?: false;
+  hideIcon?: false;
   }) => {
     // We include textcontent here bc there could be multiple smartblocks in a block
-    const regex = new RegExp(
-      `{{(${textContent.replace(/\+/g, "\\+")}):(?:42)?SmartBlock:(.*?)}}`
-    );
-    const match = regex.exec(text);
-    if (match) {
-      const {
-        [1]: buttonContent = "",
-        [2]: buttonText = "",
-        index,
-        [0]: full,
-      } = match;
-      const [workflowName, args = ""] = buttonText.split(":");
-      const variables = Object.fromEntries(
-        args
-          .replace(/\[\[[^\]]+\]\]/g, (m) => m.replace(/,/g, "ESCAPE_COMMA"))
-          .split(",")
-          .filter((s) => !!s)
-          .map((v) => v.replace(/ESCAPE_COMMA/g, ",").split("="))
-          .map(([k, v = ""]) => [k, v])
-      );
-      variables["ButtonContent"] = buttonContent;
+    const label = textContent.trim();
+    const parsed = parseSmartBlockButton(label, text);
+    if (parsed) {
+      const { index, full, buttonContent, workflowName, variables } = parsed;
       const clickListener = () => {
         const workflows = getCustomWorkflows();
         const availableWorkflows = getCleanCustomWorkflows(workflows);
@@ -766,8 +750,7 @@ export default runExtension(async ({ extensionAPI }) => {
       const parentUid = getBlockUidFromTarget(b);
       if (
         parentUid &&
-        !b.hasAttribute("data-roamjs-smartblock-button") &&
-        b.textContent
+        !b.hasAttribute("data-roamjs-smartblock-button")
       ) {
         const text = getTextByBlockUid(parentUid);
         b.setAttribute("data-roamjs-smartblock-button", "true");

--- a/src/utils/parseSmartBlockButton.ts
+++ b/src/utils/parseSmartBlockButton.ts
@@ -1,0 +1,51 @@
+export const parseSmartBlockButton = (
+  label: string,
+  text: string
+):
+  | {
+      index: number;
+      full: string;
+      buttonContent: string;
+      buttonText: string;
+      workflowName: string;
+      variables: Record<string, string>;
+    }
+  | null => {
+  const trimmedLabel = label.trim();
+  const buttonRegex = trimmedLabel
+    ? new RegExp(
+        `{{(${trimmedLabel.replace(/\\+/g, "\\+")}):(?:42)?SmartBlock:(.*?)}}`
+      )
+    : /{{\s*:(?:42)?SmartBlock:(.*?)}}/;
+  const match = buttonRegex.exec(text);
+  if (!match) return null;
+  const index = match.index;
+  const full = match[0];
+  const buttonContent = trimmedLabel ? match[1] || "" : "";
+  const buttonText = trimmedLabel ? match[2] : match[1];
+  const colonIndex = buttonText.indexOf(":");
+  const workflowName =
+    colonIndex > -1 ? buttonText.substring(0, colonIndex) : buttonText;
+  const args = colonIndex > -1 ? buttonText.substring(colonIndex + 1) : "";
+  const variables = Object.fromEntries(
+    args
+      .replace(/\[\[[^\]]+\]\]|<%[^%]+%>/g, (m) =>
+        m.replace(/,/g, "ESCAPE_COMMA")
+      )
+      .split(",")
+      .filter((s) => !!s)
+      .map((v) => v.replace(/ESCAPE_COMMA/g, ",").split("="))
+      .map(([k, v = ""]) => [k, v])
+  );
+  variables["ButtonContent"] = buttonContent;
+  return {
+    index,
+    full,
+    buttonContent,
+    buttonText,
+    workflowName,
+    variables,
+  };
+};
+
+export default parseSmartBlockButton;

--- a/tests/buttonParsing.test.ts
+++ b/tests/buttonParsing.test.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+import parseSmartBlockButton from "../src/utils/parseSmartBlockButton";
+
+test("parses SmartBlock button without label", () => {
+  const text = "{{:SmartBlock:deleteBlock:Icon=locate}}";
+  const result = parseSmartBlockButton("", text);
+  expect(result).toBeTruthy();
+  expect(result?.index).toBe(0);
+  expect(result?.full).toBe(text);
+  expect(result?.buttonContent).toBe("");
+  expect(result?.buttonText).toBe("deleteBlock:Icon=locate");
+  expect(result?.variables).toMatchObject({
+    Icon: "locate",
+    ButtonContent: "",
+  });
+});
+
+test("parses SmartBlock button with variables", () => {
+  const text =
+    "{{randomChild:SmartBlock:randomChild:RemoveButton=false,Order=<%RANDOMNUMBER:1,10%>}}";
+  const result = parseSmartBlockButton("randomChild", text);
+  expect(result).toBeTruthy();
+  expect(result?.index).toBe(0);
+  expect(result?.full).toBe(text);
+  expect(result?.buttonContent).toBe("randomChild");
+  expect(result?.buttonText).toBe(
+    "randomChild:RemoveButton=false,Order=<%RANDOMNUMBER:1,10%>"
+  );
+  expect(result?.variables).toMatchObject({
+    RemoveButton: "false",
+    Order: "<%RANDOMNUMBER:1,10%>",
+    ButtonContent: "randomChild",
+  });
+});
+
+test("parses SmartBlock button with workflow containing spaces", () => {
+  const text =
+    "{{Add New Meeting Entry:SmartBlock:1on1 Meeting - Date Select:RemoveButton=false}}";
+  const result = parseSmartBlockButton("Add New Meeting Entry", text);
+  expect(result).toBeTruthy();
+  expect(result?.workflowName).toBe("1on1 Meeting - Date Select");
+  expect(result?.variables).toMatchObject({
+    RemoveButton: "false",
+    ButtonContent: "Add New Meeting Entry",
+  });
+});
+
+test("parses SmartBlock button with sibling directive", () => {
+  const text =
+    "{{testSibling:SmartBlock:testSibling:Sibling=next,RemoveButton=false}}";
+  const result = parseSmartBlockButton("testSibling", text);
+  expect(result?.variables).toMatchObject({
+    Sibling: "next",
+    RemoveButton: "false",
+    ButtonContent: "testSibling",
+  });
+});
+
+test("parses SmartBlock button for today's entry", () => {
+  const text =
+    `{{Create Today's Entry:SmartBlock:UserDNPToday:RemoveButton=false}}`;
+  const result = parseSmartBlockButton("Create Today's Entry", text);
+  expect(result?.workflowName).toBe("UserDNPToday");
+  expect(result?.variables).toMatchObject({
+    RemoveButton: "false",
+    ButtonContent: "Create Today's Entry",
+  });
+});


### PR DESCRIPTION
## Summary
- allow SmartBlock buttons to omit the caption
- document using icon-only buttons by skipping the label
- add unit tests covering SmartBlock button parsing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689787e1076083269001fdc1aec90bf9